### PR TITLE
terraform rds etl lambda, unsure about image URI however

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -7,8 +7,10 @@ These files are needed for all AWS resource creation.
 Add a `terraform.tfvars` file in this directory with your AWS access key and secret access key.
 
 ```
-AWS_ACCESS_KEY="[your_access_key]"
-AWS_SECRET_ACCESS_KEY="[your_secret_access_key]"
+AWS_ACCESS_KEY_AJLDKA="[your_access_key]"
+AWS_SECRET_ACCESS_KEY_AJLDKA="[your_secret_access_key]"
+
+
 ```
 
 ## Usage

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -57,3 +57,45 @@ resource "aws_glue_crawler" "c19_ajldka_glue_crawler_lmnh_plants" {
     path = "s3://${aws_s3_bucket.c19_ajldka_s3_lmnh_plants.bucket}"
   }
 }
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "c19_ajldka_lambda_rds_etl_role_lmnh_plants" {
+  name               = "c19-ajldka-lambda-rds-etl-role-lmnh-plants"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+}
+
+resource "aws_lambda_function" "c19_ajldka_lambda_function_lmnh_plants_rds_etl" {
+  function_name = "c19-ajldka-lambda-rds-etl"
+  role = aws_iam_role.example.arn
+  package_type = "Image"
+  image_uri = "" # TODO: Slightly confused about this, we need the image URI of 
+                  # the container image which we will have once it is launched, however how can 
+                  # have this as a fixed value if the image uri of the container is going to change if it is launched in the future? 
+  timeout = 300
+  memory_size = 1024
+  environment {
+    variables = {
+      AWS_ACCESS_KEY_AJLDKA = var.AWS_ACCESS_KEY
+      AWS_SECRET_ACCESS_KEY_AJLDKA = var.AWS_SECRET_ACCESS_KEY
+      DB_HOST=var.DB_HOST
+      DB_PORT=var.DB_PORT
+      DB_NAME=var.DB_NAME
+      DB_USER=var.DB_USER
+      DB_PASSWORD=var.DB_PASSWORD
+      DB_DRIVER=var.DB_DRIVER
+      DB_SCHEMA=var.DB_SCHEMA
+    }
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -10,3 +10,31 @@ variable "AWS_REGION" {
     type        = string
     default     = "eu-west-2"
 }
+
+variable DB_HOST {
+    type = string
+}
+
+variable DB_PORT {
+    type = number
+}
+
+variable DB_NAME {
+    type = string
+}
+
+variable DB_USER {
+    type = string
+}
+
+variable DB_PASSWORD {
+    type = string
+}
+
+variable DB_DRIVER {
+    type = string
+}
+
+variable DB_SCHEMA {
+    type = string
+}


### PR DESCRIPTION
Unsure about how to fill in the `image` field for the Lambda without uploading the docker image for the etl script to the ECR. Something we can discuss soon as we will need it for the pipeline to start running. 